### PR TITLE
DON'T MERGE IN: Message Hub REST instead of Redis

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 node_modules
+VCAP_SERVICES.json

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # limitations under the License.
 #
 /node_modules
+npm-debug.log
+VCAP_SERVICES.json

--- a/manifest.yml
+++ b/manifest.yml
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 declared-services:
-  redis-chatter:
-    label: rediscloud
-    plan:  30mb
+  kafka-chatter:
+    label: messagehub
+    plan:  standard
 applications:
 - name: bluechatter
   memory: 128M
   command: node app.js
   services:
-  - redis-chatter
+  - kafka-chatter

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "commander": "^2.6.0",
     "express": "3.4.8",
     "http-post": "^0.1.1",
+    "message-hub-rest": "git+https://github.com/kauffecup/message-hub-rest.git#one-request-per-topic",
     "nconf": "^0.7.2",
-    "redis": "*",
     "sleep": "^3.0.0"
   },
   "repository": {


### PR DESCRIPTION
These are the code changes necessary to get bluechatter working with the IBM Message Hub service instead of with Redis (with updated README and manifest.yml)

The only thing preventing me from having you merge it in is my inability to figure out how to get this to work locally via Docker. When deployed it's simple - all you have to do is bind the service. The issue is with how the npm library works - rather than implementing the security protocol needed to connect to kafka directly, there is a separate REST api for the Message Hub service. What this means is we can't spin up a kafka docker container and connect to that locally. The only way to run locally then, is to provision an instance of the message hub service, get those login credentials, and connect to Bluemix.

If that's ok with you I can include that in the README along w/ instructions on how to do it. But if not, we'll have to figure out alternatives / if it's worth going further down this path.