### PR TITLE
Removing manual sleep timeout as redis client retries automatically.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "express": "3.4.8",
     "http-post": "^0.1.1",
     "nconf": "^0.7.2",
-    "redis": "*",
-    "sleep": "^3.0.0"
+    "redis": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The Redis client automatically retries to connect to the server on
connection issues. Rather than waiting for a fixed time period before
connecting, we can leave this logic to the redis client. Looking at the
error thrown, we print out a message informing the user we are in the
waiting for networking state.

@ryanjbaxter - do this look good? I've tested it locally and running on IBM containers. 