### PR TITLE
Allow compose-redis creds outside of VCAP_SERVICES

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,7 +62,7 @@ if (process.env.VCAP_SERVICES) {
             console.log('There appears to be no redis-cloud service bound to this application.');
         }
     }
-} else {
+} else if (process.env.COMPOSE_REDIS_URI) {
   connectionString = process.env.COMPOSE_REDIS_URI
   url_hostname = new URL(connectionString).hostname
   url_port = new URL(connectionString).port

--- a/app.js
+++ b/app.js
@@ -62,6 +62,13 @@ if (process.env.VCAP_SERVICES) {
             console.log('There appears to be no redis-cloud service bound to this application.');
         }
     }
+} else {
+  connectionString = process.env.COMPOSE_REDIS_URI
+  url_hostname = new URL(connectionString).hostname
+  url_port = new URL(connectionString).port
+  password = new URL(connectionString).password
+
+  credentials = {"hostname": url_hostname, "port": url_port, "password": password};
 }
 
 // We need two Redis clients - one to listen for events, and one to publish events.
@@ -69,7 +76,7 @@ if (process.env.VCAP_SERVICES) {
 
 if(connectionString != null) {
     if(connectionString.includes("rediss")) {
-        var subscriber = redis.createClient(connectionString,  
+        var subscriber = redis.createClient(connectionString,
                   { tls: { servername: new URL(connectionString).hostname} }
         );
         var publisher = redis.createClient(connectionString,


### PR DESCRIPTION
@Twanawebtech This is an addendum to @nihillno 's previous update. This allows the compose-for-redis credentials to be set as a standard environment variable as opposed to an only-CF context with VCAP_SERVICES.

Our demo automation uses Kubernetes pods and we'd like this addition to the code to allow setting of service-keys through environment variables on the pod. 